### PR TITLE
junit-jupiter-engine in dependencies

### DIFF
--- a/junit5-hello-world/pom.xml
+++ b/junit5-hello-world/pom.xml
@@ -25,7 +25,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -42,11 +42,6 @@
 						<groupId>org.junit.platform</groupId>
 						<artifactId>junit-platform-surefire-provider</artifactId>
 						<version>${junit.platform.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.junit.jupiter</groupId>
-						<artifactId>junit-jupiter-engine</artifactId>
-						<version>${junit.jupiter.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
See #4 

To avoid this exception when running from Eclipse (note that this way of
declaring dependency is also shown in the official JUnit 5 examples,
https://github.com/junit-team/junit5-samples/blob/r5.0.3/junit5-vanilla-maven/pom.xml)

java.lang.NoClassDefFoundError:
org/junit/platform/engine/EngineDiscoveryRequest
	at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:59)
	at org.eclipse.jdt.internal.junit5.runner.JUnit5TestLoader.<init>(JUnit5TestLoader.java:31)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native
Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.createRawTestLoader(RemoteTestRunner.java:367)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.createLoader(RemoteTestRunner.java:362)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.defaultInit(RemoteTestRunner.java:306)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.init(RemoteTestRunner.java:221)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:205)
Caused by: java.lang.ClassNotFoundException:
org.junit.platform.engine.EngineDiscoveryRequest
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 12 more